### PR TITLE
Update direct database URL variable name

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,7 +5,7 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
-  directUrl = env("DIRECT_DATABASE_URL")
+  directUrl = env("DATABASE_DIRECT_URL")
 }
 
 


### PR DESCRIPTION
This pull request updates the variable name for the direct database URL from `DIRECT_DATABASE_URL` to `DATABASE_DIRECT_URL`.