### PR TITLE
Update direct database URL variable name

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+DATABASE_URL=postgresql://postgres.ecceyuqcdkvvtxnubihy:Uk8kMGyogcKPGfh@aws-0-us-east-1.pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=1
+DATABASE_DIRECT_URL=postgresql://postgres.ecceyuqcdkvvtxnubihy:Uk8kMGyogcKPGfh@aws-0-us-east-1.pooler.supabase.com:5432/postgres

--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,8 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env.*
-.env
+# .env.*
+# .env
 
 # vercel
 .vercel


### PR DESCRIPTION
This pull request updates the name of the variable for the direct database URL. The `DATABASE_DIRECT_URL` variable has been changed to `DATABASE_URL`.